### PR TITLE
Normalize filter segments for case-insensitive API queries

### DIFF
--- a/learn-quest-backend/src/Controller/Api/ApiEntityController.php
+++ b/learn-quest-backend/src/Controller/Api/ApiEntityController.php
@@ -38,6 +38,11 @@ final class ApiEntityController extends AbstractController
             $path        = [];
 
             foreach ($parts as $i => $part) {
+                // allow case-insensitive filter keys by normalising the
+                // segment to match the property name convention used in the
+                // entities (camelCase with a lowercase first letter)
+                $part = lcfirst($part);
+
                 $isLast = $i === count($parts) - 1;
                 $path[] = $part;
                 $pathKey = implode('_', $path);


### PR DESCRIPTION
## Summary
- normalize filter key segments to camelCase before building Doctrine query

## Testing
- `php -l learn-quest-backend/src/Controller/Api/ApiEntityController.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893980cd27083239732d11d197a567e