### PR TITLE
feat: confirm enrollment and show enrolled state

### DIFF
--- a/learn-quest-app/src/app/components/buttons/footer-button/footer-button.component.html
+++ b/learn-quest-app/src/app/components/buttons/footer-button/footer-button.component.html
@@ -1,1 +1,3 @@
-<button (click)="emit()" class="card-footer btn btn-primary w-100">{{ text }}</button>
+<button (click)="emit()"
+        [disabled]="disabled"
+        [class]="'card-footer btn w-100 ' + btnClass">{{ text }}</button>

--- a/learn-quest-app/src/app/components/buttons/footer-button/footer-button.component.ts
+++ b/learn-quest-app/src/app/components/buttons/footer-button/footer-button.component.ts
@@ -8,9 +8,21 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 })
 export class FooterButtonComponent {
   @Input() text: string = 'Submit';
+  /**
+   * CSS class applied to the button. Defaults to Bootstrap's primary button.
+   */
+  @Input() btnClass: string = 'btn-primary';
+  /**
+   * Whether the button is disabled.
+   */
+  @Input() disabled: boolean = false;
   @Output() click: EventEmitter<any> = new EventEmitter();
 
   emit() {
-    this.click.emit();
+    // Even though a disabled button won't emit click events, this check
+    // guards against programmatic calls to emit when disabled.
+    if (!this.disabled) {
+      this.click.emit();
+    }
   }
 }

--- a/learn-quest-app/src/app/view/user/lessons/lessons.component.html
+++ b/learn-quest-app/src/app/view/user/lessons/lessons.component.html
@@ -12,4 +12,11 @@
     </td>
   </tr>
 </table>
-<app-footer-button [text]="'Enroll'" (click)="enroll()"></app-footer-button>
+<div *ngIf="showEnrollNotification" class="alert alert-success mt-3">
+  Enrolled successfully! Go to
+  <a routerLink="/user/dashboard" class="alert-link">your dashboard</a>.
+</div>
+<app-footer-button [text]="isEnrolled() ? 'Enrolled' : 'Enroll'"
+                   [btnClass]="isEnrolled() ? 'btn-success' : 'btn-primary'"
+                   [disabled]="isEnrolled()"
+                   (click)="enroll()"></app-footer-button>

--- a/learn-quest-app/src/app/view/user/lessons/lessons.component.ts
+++ b/learn-quest-app/src/app/view/user/lessons/lessons.component.ts
@@ -5,7 +5,7 @@ import {Course} from '../../../entities/course';
 import {IconComponent} from '../../../components/icon/icon.component';
 import {FooterButtonComponent} from '../../../components/buttons/footer-button/footer-button.component';
 import {Lesson} from '../../../entities/lesson';
-import {Router} from '@angular/router';
+import {Router, RouterLink} from '@angular/router';
 import {NgForOf} from '@angular/common';
 
 @Component({
@@ -13,13 +13,16 @@ import {NgForOf} from '@angular/common';
   imports: [
     IconComponent,
     FooterButtonComponent,
-    NgForOf
+    NgForOf,
+    RouterLink
   ],
   templateUrl: './lessons.component.html',
   styleUrl: './lessons.component.css'
 })
 export class LessonsComponent implements OnInit {
   @Input() courseId: number = 0;
+
+  showEnrollNotification = false;
 
   constructor(
     private courseService: CourseService,
@@ -49,12 +52,25 @@ export class LessonsComponent implements OnInit {
     // Load the course and lessons when the component initializes
     this.courseService.loadCourses({id: this.courseId});
     this.lessonService.loadLessons({courseId: this.courseId});
+    // Load courses the user is enrolled in to update the button state
+    this.courseService.loadEnrolledCourses();
+  }
+
+  isEnrolled(): boolean {
+    return this.courseService
+      .getEnrolledCourses()
+      .some(course => course.id === this.courseId);
   }
 
   enroll() {
+    if (this.isEnrolled()) {
+      return;
+    }
     this.courseService.enrollInCourse(this.courseId).subscribe({
       next: (response: any) => {
-        // Optionally, you can reload the courses after enrollment
+        // Reload the enrolled courses and show a confirmation
+        this.courseService.loadEnrolledCourses(true);
+        this.showEnrollNotification = true;
         console.log('Enrolled in course:', response);
       }
     });


### PR DESCRIPTION
## Summary
- show enrollment confirmation with dashboard link
- allow footer button to accept custom class and disabled state
- mark enrolled courses and disable the enroll button

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68939ff8e4048323a6b5c9db12a8faa0