### PR TITLE
feat: scaffold lesson sections

### DIFF
--- a/learn-quest-app/src/app/app.routes.ts
+++ b/learn-quest-app/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import {DashboardComponent} from './view/dashboard/dashboard.component';
 import {jwtAuthGuard} from './auth/jwt-auth.guard';
 import {CoursesComponent} from './view/user/courses/courses.component';
 import {LessonsComponent} from './view/user/lessons/lessons.component';
+import {LessonSectionCreateComponent} from './view/lesson-section-create/lesson-section-create.component';
 
 export const routes: Routes = [
   {component: LoginComponent, path: '', title: 'Login'},
@@ -11,4 +12,5 @@ export const routes: Routes = [
   {component: DashboardComponent, path: 'user/dashboard', title: 'Dashboard', canActivate: [jwtAuthGuard]},
   {component: CoursesComponent, path: 'user/courses', title: 'Courses', canActivate: [jwtAuthGuard]},
   {component: LessonsComponent, path: 'user/course', title: 'Course', canActivate: [jwtAuthGuard]},
+  {component: LessonSectionCreateComponent, path: 'teacher/lesson-section/create', title: 'Create Lesson Section', canActivate: [jwtAuthGuard]},
 ];

--- a/learn-quest-app/src/app/entities/entity.spec.ts
+++ b/learn-quest-app/src/app/entities/entity.spec.ts
@@ -1,7 +1,9 @@
 import { Entity } from './entity';
 
+class TestEntity extends Entity {}
+
 describe('Entity', () => {
   it('should create an instance', () => {
-    expect(new Entity()).toBeTruthy();
+    expect(new TestEntity()).toBeTruthy();
   });
 });

--- a/learn-quest-app/src/app/entities/lesson-section.spec.ts
+++ b/learn-quest-app/src/app/entities/lesson-section.spec.ts
@@ -1,0 +1,7 @@
+import { LessonSection } from './lesson-section';
+
+describe('LessonSection', () => {
+  it('should create an instance', () => {
+    expect(new LessonSection()).toBeTruthy();
+  });
+});

--- a/learn-quest-app/src/app/entities/lesson-section.ts
+++ b/learn-quest-app/src/app/entities/lesson-section.ts
@@ -1,0 +1,8 @@
+import {Entity} from './entity';
+
+export class LessonSection extends Entity {
+  lessonId: number = 0;
+  type: string = '';
+  content: string = '';
+  position: number = 0;
+}

--- a/learn-quest-app/src/app/services/entity-cache.service.spec.ts
+++ b/learn-quest-app/src/app/services/entity-cache.service.spec.ts
@@ -1,13 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-
 import { EntityCacheService } from './entity-cache.service';
 
 describe('EntityCacheService', () => {
-  let service: EntityCacheService;
+  let service: EntityCacheService<any>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(EntityCacheService);
+    service = TestBed.inject<EntityCacheService<any>>(EntityCacheService);
   });
 
   it('should be created', () => {

--- a/learn-quest-app/src/app/services/lesson-section.service.spec.ts
+++ b/learn-quest-app/src/app/services/lesson-section.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LessonSectionService } from './lesson-section.service';
+
+describe('LessonSectionService', () => {
+  let service: LessonSectionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LessonSectionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/learn-quest-app/src/app/services/lesson-section.service.ts
+++ b/learn-quest-app/src/app/services/lesson-section.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { EntityCacheService } from './entity-cache.service';
+import { LessonSection } from '../entities/lesson-section';
+import { ApiService } from './api.service';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LessonSectionService {
+
+  constructor(private cacheService: EntityCacheService<LessonSection>, private apiService: ApiService) {}
+
+  loadSections(params: {[key: string]: any} = {}, forceReload = false): void {
+    this.cacheService.loadEntities('lesson_section/index', LessonSection, params, forceReload);
+  }
+
+  getSections(params: {[key: string]: any} = {}): LessonSection[] {
+    return this.cacheService.filterCachedEntities(LessonSection, params);
+  }
+
+  createSection(section: LessonSection): Observable<LessonSection> {
+    return this.apiService.post<LessonSection>('lesson_section/create', section);
+  }
+
+  clearCache() {
+    this.cacheService.clearCache(LessonSection);
+  }
+}

--- a/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.css
+++ b/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.css
@@ -1,0 +1,1 @@
+/* Styles for lesson section form */

--- a/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.html
+++ b/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.html
@@ -1,0 +1,23 @@
+<form (ngSubmit)="submit()" #sectionForm="ngForm">
+  <div>
+    <label>Lesson ID</label>
+    <input type="number" [(ngModel)]="section.lessonId" name="lessonId" required>
+  </div>
+  <div>
+    <label>Type</label>
+    <select [(ngModel)]="section.type" name="type" required>
+      <option value="text">Text</option>
+      <option value="widget">Widget</option>
+      <option value="question">Question</option>
+    </select>
+  </div>
+  <div>
+    <label>Content</label>
+    <textarea [(ngModel)]="section.content" name="content"></textarea>
+  </div>
+  <div>
+    <label>Position</label>
+    <input type="number" [(ngModel)]="section.position" name="position" required>
+  </div>
+  <button type="submit">Create Section</button>
+</form>

--- a/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.spec.ts
+++ b/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LessonSectionCreateComponent } from './lesson-section-create.component';
+
+describe('LessonSectionCreateComponent', () => {
+  let component: LessonSectionCreateComponent;
+  let fixture: ComponentFixture<LessonSectionCreateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LessonSectionCreateComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LessonSectionCreateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.ts
+++ b/learn-quest-app/src/app/view/lesson-section-create/lesson-section-create.component.ts
@@ -1,0 +1,24 @@
+import {Component} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {LessonSection} from '../../entities/lesson-section';
+import {LessonSectionService} from '../../services/lesson-section.service';
+
+@Component({
+  selector: 'app-lesson-section-create',
+  imports: [FormsModule],
+  templateUrl: './lesson-section-create.component.html',
+  styleUrl: './lesson-section-create.component.css'
+})
+export class LessonSectionCreateComponent {
+  section: LessonSection = new LessonSection();
+
+  constructor(private lessonSectionService: LessonSectionService) {}
+
+  submit() {
+    this.lessonSectionService.createSection(this.section).subscribe({
+      next: () => {
+        this.section = new LessonSection();
+      }
+    });
+  }
+}

--- a/learn-quest-backend/migrations/Version20250807180000.php
+++ b/learn-quest-backend/migrations/Version20250807180000.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250807180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create lesson_section table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE lesson_section (id INT AUTO_INCREMENT NOT NULL, lesson_id INT NOT NULL, type VARCHAR(50) NOT NULL, content LONGTEXT DEFAULT NULL, position INT NOT NULL, INDEX IDX_lesson_section_lesson_id (lesson_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE lesson_section ADD CONSTRAINT FK_lesson_section_lesson FOREIGN KEY (lesson_id) REFERENCES lesson (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE lesson_section');
+    }
+}

--- a/learn-quest-backend/src/Controller/Api/ApiLessonSectionController.php
+++ b/learn-quest-backend/src/Controller/Api/ApiLessonSectionController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Entity\Lesson;
+use App\Entity\LessonSection;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/api/lesson_section', methods: ['POST', 'GET'])]
+final class ApiLessonSectionController extends AbstractController
+{
+    public function __construct(private readonly ManagerRegistry $doctrine)
+    {
+    }
+
+    #[Route('/create', name: 'app_api_lesson_section_create', methods: ['POST'])]
+    public function create(Request $request): Response
+    {
+        if (!$this->isGranted('ROLE_ADMIN') && !$this->isGranted('ROLE_TEACHER')) {
+            return $this->json(['error' => 'Access denied'], Response::HTTP_FORBIDDEN);
+        }
+
+        $data = json_decode($request->getContent(), true);
+        if (!$data) {
+            return $this->json(['error' => 'Invalid JSON body'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $lessonId = (int) ($data['lessonId'] ?? 0);
+        $type = $data['type'] ?? null;
+        $content = $data['content'] ?? null;
+        $position = (int) ($data['position'] ?? 0);
+
+        if (!$lessonId || !$type) {
+            return $this->json(['error' => 'lessonId and type are required'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $lesson = $this->doctrine->getRepository(Lesson::class)->find($lessonId);
+        if (!$lesson) {
+            return $this->json(['error' => 'Lesson not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $section = new LessonSection();
+        $section->setLesson($lesson);
+        $section->setType($type);
+        $section->setContent($content);
+        $section->setPosition($position);
+
+        $em = $this->doctrine->getManager();
+        $em->persist($section);
+        $em->flush();
+
+        return $this->json([
+            'id' => $section->getId(),
+            'lessonId' => $section->getLessonId(),
+            'type' => $section->getType(),
+            'content' => $section->getContent(),
+            'position' => $section->getPosition(),
+        ], Response::HTTP_CREATED);
+    }
+}

--- a/learn-quest-backend/src/Dto/LessonSectionDto.php
+++ b/learn-quest-backend/src/Dto/LessonSectionDto.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Dto;
+
+class LessonSectionDto extends Dto
+{
+    public function __construct(
+        public ?int $id = null,
+        public ?int $lessonId = null,
+        public ?string $type = null,
+        public ?string $content = null,
+        public ?int $position = null,
+    ) {
+    }
+}

--- a/learn-quest-backend/src/Entity/Lesson.php
+++ b/learn-quest-backend/src/Entity/Lesson.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Repository\LessonRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\UX\Turbo\Attribute\Broadcast;
 
@@ -35,6 +37,17 @@ class Lesson
 
     #[ORM\Column(length: 255)]
     private ?string $faIcon = null;
+
+    /**
+     * @var Collection<int, LessonSection>
+     */
+    #[ORM\OneToMany(targetEntity: LessonSection::class, mappedBy: 'lesson', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $sections;
+
+    public function __construct()
+    {
+        $this->sections = new ArrayCollection();
+    }
 
     public function getId(): ?int
     {
@@ -125,6 +138,35 @@ class Lesson
     public function setFaIcon(string $faIcon): static
     {
         $this->faIcon = $faIcon;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, LessonSection>
+     */
+    public function getSections(): Collection
+    {
+        return $this->sections;
+    }
+
+    public function addSection(LessonSection $section): static
+    {
+        if (!$this->sections->contains($section)) {
+            $this->sections->add($section);
+            $section->setLesson($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSection(LessonSection $section): static
+    {
+        if ($this->sections->removeElement($section)) {
+            if ($section->getLesson() === $this) {
+                $section->setLesson(null);
+            }
+        }
 
         return $this;
     }

--- a/learn-quest-backend/src/Entity/LessonSection.php
+++ b/learn-quest-backend/src/Entity/LessonSection.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\LessonSectionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\UX\Turbo\Attribute\Broadcast;
+
+#[ORM\Entity(repositoryClass: LessonSectionRepository::class)]
+#[Broadcast]
+class LessonSection
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Lesson::class, inversedBy: 'sections')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Lesson $lesson = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?int $lessonId = null;
+
+    #[ORM\Column(length: 50)]
+    private ?string $type = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    #[ORM\Column]
+    private int $position = 0;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getLesson(): ?Lesson
+    {
+        return $this->lesson;
+    }
+
+    public function setLesson(?Lesson $lesson): static
+    {
+        $this->lesson = $lesson;
+        $this->lessonId = $lesson?->getId();
+
+        return $this;
+    }
+
+    public function getLessonId(): ?int
+    {
+        return $this->lessonId;
+    }
+
+    public function setLessonId(?int $lessonId): static
+    {
+        $this->lessonId = $lessonId;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(?string $content): static
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): static
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+}

--- a/learn-quest-backend/src/Form/Type/LessonSectionType.php
+++ b/learn-quest-backend/src/Form/Type/LessonSectionType.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Form\Type;
+
+use App\Entity\Lesson;
+use App\Entity\LessonSection;
+use App\Subscriber\HashPasswordSubscriber;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class LessonSectionType extends AbstractType
+{
+    public function __construct(
+        private readonly HashPasswordSubscriber $subscriber
+    ) {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('lesson', EntityType::class, [
+                'class' => Lesson::class,
+                'choice_label' => 'name',
+            ])
+            ->add('type', ChoiceType::class, [
+                'choices' => [
+                    'Text' => 'text',
+                    'Widget' => 'widget',
+                    'Question' => 'question',
+                ],
+            ])
+            ->add('content', TextareaType::class, [
+                'required' => false,
+            ])
+            ->add('position', IntegerType::class);
+
+        $builder->addEventSubscriber($this->subscriber);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => LessonSection::class,
+            'csrf_protection' => true,
+            'csrf_field_name' => '_token',
+            'csrf_token_id' => 'lesson_section_item',
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'lesson_section';
+    }
+}

--- a/learn-quest-backend/src/Repository/LessonSectionRepository.php
+++ b/learn-quest-backend/src/Repository/LessonSectionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LessonSection;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LessonSection>
+ */
+class LessonSectionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LessonSection::class);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold backend lesson sections with entity, DTO, form, API and migration
- add Angular entity, service, component and route for creating lesson sections

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_689494430f908323b68a76a8914cc13c